### PR TITLE
Fix triggering in CI pipeline

### DIFF
--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -2,9 +2,9 @@ name: Android CI
 
 on:
   push:
-    branches: [ main, feature/* ]
+    branches: [ master, feature/*, chore/*, fix/* ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
   workflow_dispatch: # Allows manual triggering
 
 jobs:


### PR DESCRIPTION
The pipeline was wrongly triggered for main but in this repository master is the main branch.
Also chore/* and fix/* branches are added to the trigger of workflows.