### PR TITLE
refactor: Make state collection consistent across the project

### DIFF
--- a/app/src/main/java/de/marquisproject/finotes/MainActivity.kt
+++ b/app/src/main/java/de/marquisproject/finotes/MainActivity.kt
@@ -11,8 +11,9 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalSharedTransitionApi
-import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -35,9 +36,10 @@ class MainActivity : ComponentActivity() {
         setContent {
             val navController = rememberNavController()
             val settingsViewModel: SettingsViewModel = hiltViewModel()
+            val themeVariant by settingsViewModel.themeVariant.collectAsStateWithLifecycle()
 
             FinotesTheme(
-                themeVariant = settingsViewModel.themeVariant.collectAsState().value
+                themeVariant = themeVariant
             ) {
                 NavHost(
                     navController = navController,

--- a/app/src/main/java/de/marquisproject/finotes/ui/screens/ArchiveScreen.kt
+++ b/app/src/main/java/de/marquisproject/finotes/ui/screens/ArchiveScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
@@ -25,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import de.marquisproject.finotes.NoteRoute
 import de.marquisproject.finotes.R
 import de.marquisproject.finotes.ui.components.NotesList
@@ -41,10 +41,10 @@ fun ArchiveScreen(
 
     val viewModel: ArchiveViewModel = hiltViewModel()
 
-    val inSelectionMode by viewModel.inSelectionMode.collectAsState()
-    val selectedNotes by viewModel.selectedNotes.collectAsState()
-    val searchQuery by viewModel.searchQuery.collectAsState()
-    val notesList by viewModel.notesList.collectAsState()
+    val inSelectionMode by viewModel.inSelectionMode.collectAsStateWithLifecycle()
+    val selectedNotes by viewModel.selectedNotes.collectAsStateWithLifecycle()
+    val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
+    val notesList by viewModel.notesList.collectAsStateWithLifecycle()
 
     BackHandler {
         if (inSelectionMode) {

--- a/app/src/main/java/de/marquisproject/finotes/ui/screens/BinScreen.kt
+++ b/app/src/main/java/de/marquisproject/finotes/ui/screens/BinScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
@@ -31,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import de.marquisproject.finotes.NoteRoute
 import de.marquisproject.finotes.R
 import de.marquisproject.finotes.ui.components.NotesList
@@ -47,10 +47,10 @@ fun BinScreen(
 ) {
     val viewModel: BinViewModel = hiltViewModel()
     //val notesList by viewModel.
-    val inSelectionMode by viewModel.inSelectionMode.collectAsState()
-    val selectedNotes by viewModel.selectedNotes.collectAsState()
-    val notesList by viewModel.notesList.collectAsState()
-    val searchQuery by viewModel.searchQuery.collectAsState()
+    val inSelectionMode by viewModel.inSelectionMode.collectAsStateWithLifecycle()
+    val selectedNotes by viewModel.selectedNotes.collectAsStateWithLifecycle()
+    val notesList by viewModel.notesList.collectAsStateWithLifecycle()
+    val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
     val openFinalDeleteAlert = remember { mutableStateOf(false) }
 
     BackHandler {

--- a/app/src/main/java/de/marquisproject/finotes/ui/screens/ExportImportScreen.kt
+++ b/app/src/main/java/de/marquisproject/finotes/ui/screens/ExportImportScreen.kt
@@ -18,11 +18,11 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -40,9 +40,9 @@ fun ExportImportScreen(
     val iEviewModel: ImportExportViewModel = hiltViewModel()
 
     val navControllerIE = rememberNavController()
-    val importExportMode by iEviewModel.importExportMode.collectAsState()
-    val loadedData = iEviewModel.loadedData.collectAsState()
-    val notesLoaded = loadedData.value.notes.isNotEmpty() || loadedData.value.archivedNotes.isNotEmpty()
+    val importExportMode by iEviewModel.importExportMode.collectAsStateWithLifecycle()
+    val loadedData by iEviewModel.loadedData.collectAsStateWithLifecycle()
+    val notesLoaded = loadedData.notes.isNotEmpty() || loadedData.archivedNotes.isNotEmpty()
 
 
     Scaffold(

--- a/app/src/main/java/de/marquisproject/finotes/ui/screens/ExportScreen.kt
+++ b/app/src/main/java/de/marquisproject/finotes/ui/screens/ExportScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
@@ -25,6 +24,8 @@ import de.marquisproject.finotes.ui.viewmodels.ExportFileFormat
 import de.marquisproject.finotes.ui.viewmodels.ImportExportMode
 import de.marquisproject.finotes.ui.viewmodels.ImportExportViewModel
 import android.net.Uri
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 @Composable
 fun ExportScreen(
@@ -39,8 +40,8 @@ fun ExportScreen(
     }
 
 
-    val exportSettings = iEviewModel.exportSettings.collectAsState()
-    val exportData = iEviewModel.exportData.collectAsState()
+    val exportSettings by iEviewModel.exportSettings.collectAsStateWithLifecycle()
+    val exportData by iEviewModel.exportData.collectAsStateWithLifecycle()
 
     iEviewModel.setMode(ImportExportMode.EXPORT)
 
@@ -60,14 +61,14 @@ fun ExportScreen(
                 verticalArrangement = Arrangement.Top
             ) {
                 Text("Include archived notes", style = MaterialTheme.typography.titleMedium)
-                val subtitle = if (exportSettings.value.includeArchived) "Yes" else "No"
+                val subtitle = if (exportSettings.includeArchived) "Yes" else "No"
                 Text(subtitle, style = MaterialTheme.typography.bodyMedium)
             }
             Switch(
-                checked = exportSettings.value.includeArchived,
+                checked = exportSettings.includeArchived,
                 onCheckedChange = {
                     iEviewModel.setExportSettings (
-                        exportSettings.value.copy(includeArchived = it)
+                        exportSettings.copy(includeArchived = it)
                     )
                                   },
                 modifier = Modifier.align(Alignment.CenterVertically)
@@ -79,7 +80,7 @@ fun ExportScreen(
         ) {
             Column {
                 Text("Choose export format", style = MaterialTheme.typography.titleMedium)
-                Text("${exportSettings.value.exportFileFormat}", style = MaterialTheme.typography.bodyMedium)
+                Text("${exportSettings.exportFileFormat}", style = MaterialTheme.typography.bodyMedium)
             }
         }
         Column(modifier = Modifier.selectableGroup()) {
@@ -89,10 +90,10 @@ fun ExportScreen(
                         .fillMaxWidth()
                         .height(56.dp)
                         .selectable(
-                            selected = (exportSettings.value.exportFileFormat == format),
+                            selected = (exportSettings.exportFileFormat == format),
                             onClick = {
                                 iEviewModel.setExportSettings (
-                                    exportSettings.value.copy(exportFileFormat = format)
+                                    exportSettings.copy(exportFileFormat = format)
                                 )
                             },
                             role = Role.RadioButton
@@ -101,7 +102,7 @@ fun ExportScreen(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     RadioButton(
-                        selected = (exportSettings.value.exportFileFormat == format),
+                        selected = (exportSettings.exportFileFormat == format),
                         onClick = null // null recommended for accessibility with screen readers
                     )
                     Text(
@@ -118,7 +119,7 @@ fun ExportScreen(
                       },
             modifier = Modifier.fillMaxWidth().padding(top = 30.dp)
         ) {
-            val numExportNotes = exportData.value.notes.size + exportData.value.archivedNotes.size
+            val numExportNotes = exportData.notes.size + exportData.archivedNotes.size
             Text("Export $numExportNotes notes")
         }
     }

--- a/app/src/main/java/de/marquisproject/finotes/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/de/marquisproject/finotes/ui/screens/HomeScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -31,6 +30,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import de.marquisproject.finotes.NoteRoute
 import de.marquisproject.finotes.R
@@ -50,11 +50,11 @@ fun HomeScreen(
 ) {
     val viewModel: HomeViewModel = hiltViewModel()
     
-    val inSelectionMode by viewModel.inSelectionMode.collectAsState()
-    val selectedNotes by viewModel.selectedNotes.collectAsState()
-    val searchQuery by viewModel.searchQuery.collectAsState()
-    val pinnedNotesDisplay by viewModel.pinnedNotesDisplay.collectAsState()
-    val normalNotesDisplay by viewModel.normalNotesDisplay.collectAsState()
+    val inSelectionMode by viewModel.inSelectionMode.collectAsStateWithLifecycle()
+    val selectedNotes by viewModel.selectedNotes.collectAsStateWithLifecycle()
+    val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
+    val pinnedNotesDisplay by viewModel.pinnedNotesDisplay.collectAsStateWithLifecycle()
+    val normalNotesDisplay by viewModel.normalNotesDisplay.collectAsStateWithLifecycle()
 
     // Create a SnackbarHostState to control the Snackbar
     val snackbarHostState = remember { SnackbarHostState() }

--- a/app/src/main/java/de/marquisproject/finotes/ui/screens/ImportScreen.kt
+++ b/app/src/main/java/de/marquisproject/finotes/ui/screens/ImportScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import de.marquisproject.finotes.ui.components.NoteCard
 import de.marquisproject.finotes.ui.viewmodels.ImportExportMode
 import de.marquisproject.finotes.ui.viewmodels.ImportExportViewModel
@@ -57,13 +58,13 @@ fun ImportScreen(
         }
     }
 
-    val loadedData = iEviewModel.loadedData.collectAsState()
-    val importData = iEviewModel.importData.collectAsState()
-    val notesLoaded = loadedData.value.notes.isNotEmpty() || loadedData.value.archivedNotes.isNotEmpty()
-    val openInfoAlert = iEviewModel.showFileInfoAlert.collectAsState()
-    val showFinalImportAlert = iEviewModel.showFinalImportAlert.collectAsState()
-    val onlyNonDuplicatesInImportData = iEviewModel.onlyNonDuplicatesInImportData.collectAsState()
-    val showImportLoading = iEviewModel.showImportLoading.collectAsState()
+    val loadedData by iEviewModel.loadedData.collectAsStateWithLifecycle()
+    val importData by iEviewModel.importData.collectAsStateWithLifecycle()
+    val notesLoaded = loadedData.notes.isNotEmpty() || loadedData.archivedNotes.isNotEmpty()
+    val openInfoAlert by iEviewModel.showFileInfoAlert.collectAsStateWithLifecycle()
+    val showFinalImportAlert by iEviewModel.showFinalImportAlert.collectAsStateWithLifecycle()
+    val onlyNonDuplicatesInImportData by iEviewModel.onlyNonDuplicatesInImportData.collectAsStateWithLifecycle()
+    val showImportLoading by iEviewModel.showImportLoading.collectAsStateWithLifecycle()
 
 
     iEviewModel.setMode(ImportExportMode.IMPORT)
@@ -106,7 +107,7 @@ fun ImportScreen(
                             ButtonFastSelection(
                                 onClick = { iEviewModel.selectOnlyNonDuplicates() },
                                 text = "Select non-duplicates",
-                                selected = onlyNonDuplicatesInImportData.value
+                                selected = onlyNonDuplicatesInImportData
                             )
                         }
                         item {
@@ -114,14 +115,14 @@ fun ImportScreen(
                                 onClick = { iEviewModel.deselectAllNotes() },
                                 text = "Unselect all",
                                 icon = Icons.Default.Clear,
-                                selected = importData.value.notes.isEmpty() && importData.value.archivedNotes.isEmpty()
+                                selected = importData.notes.isEmpty() && importData.archivedNotes.isEmpty()
                             )
                         }
                         item {
                             ButtonFastSelection(
                                 onClick = { iEviewModel.selectAllNotes() },
                                 text = "Select all",
-                                selected = (importData.value.notes == loadedData.value.notes && importData.value.archivedNotes == loadedData.value.archivedNotes)
+                                selected = (importData.notes == loadedData.notes && importData.archivedNotes == loadedData.archivedNotes)
                             )
                         }
                     }
@@ -149,10 +150,10 @@ fun ImportScreen(
                                 )
                             }
                             items(
-                                items = loadedData.value.notes,
+                                items = loadedData.notes,
                                 key = { note -> "note_${note.id}" }
                             ) { note ->
-                                val isSelected = importData.value.notes.contains(note)
+                                val isSelected = importData.notes.contains(note)
                                 NoteCard(
                                     note = note,
                                     selected = isSelected,
@@ -172,11 +173,11 @@ fun ImportScreen(
                                 )
                             }
                             items(
-                                items = loadedData.value.archivedNotes,
+                                items = loadedData.archivedNotes,
                                 key = { note -> "archived_${note.id}" }
                             ) { note ->
                                 val isSelected =
-                                    importData.value.archivedNotes.contains(note)
+                                    importData.archivedNotes.contains(note)
                                 NoteCard(
                                     note = note,
                                     selected = isSelected,
@@ -187,7 +188,7 @@ fun ImportScreen(
                             item(
                                 span = StaggeredGridItemSpan.FullLine
                             ) {
-                                // spacer at the bottom of heigth 200.dp
+                                // spacer at the bottom of height 200.dp
                                 Box(
                                     modifier = Modifier
                                         .fillMaxWidth()
@@ -232,16 +233,16 @@ fun ImportScreen(
                         }
                         Button(
                             onClick = { iEviewModel.setShowFinalImportAlert(true) },
-                            enabled = importData.value.notes.isNotEmpty() || importData.value.archivedNotes.isNotEmpty(),
+                            enabled = importData.notes.isNotEmpty() || importData.archivedNotes.isNotEmpty(),
                         ) {
-                            Text("Import selected Notes (${importData.value.notes.size + importData.value.archivedNotes.size})")
+                            Text("Import selected Notes (${importData.notes.size + importData.archivedNotes.size})")
                         }
                     }
                 }
             }
         }
 
-        if (showImportLoading.value) {
+        if (showImportLoading) {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -253,7 +254,7 @@ fun ImportScreen(
         }
 
         when {
-            openInfoAlert.value -> {
+            openInfoAlert -> {
                 AlertDialog(
                     onDismissRequest = { iEviewModel.setShowFileInfoAlert(false) },
                     title = {
@@ -261,7 +262,7 @@ fun ImportScreen(
                     },
                     text = {
                         Column {
-                            Text("The file contains ${loadedData.value.notes.size} notes and ${loadedData.value.archivedNotes.size} archived notes")
+                            Text("The file contains ${loadedData.notes.size} notes and ${loadedData.archivedNotes.size} archived notes")
                             Text("Select the notes you want to import and click on the import button.")
                         }
                     },
@@ -276,7 +277,7 @@ fun ImportScreen(
             }
         }
         when {
-            showFinalImportAlert.value -> {
+            showFinalImportAlert -> {
                 AlertDialog(
                     onDismissRequest = { iEviewModel.setShowFinalImportAlert(false) },
                     title = {
@@ -284,7 +285,7 @@ fun ImportScreen(
                     },
                     text = {
                         Column {
-                            Text("This will add ${importData.value.notes.size} note(s) and ${importData.value.archivedNotes.size} archived note(s) to your database.")
+                            Text("This will add ${importData.notes.size} note(s) and ${importData.archivedNotes.size} archived note(s) to your database.")
                             Text(text = buildAnnotatedString {
                                 append("This action is ")
                                 withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {

--- a/app/src/main/java/de/marquisproject/finotes/ui/screens/NoteScreen.kt
+++ b/app/src/main/java/de/marquisproject/finotes/ui/screens/NoteScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,6 +35,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import de.marquisproject.finotes.ui.components.MarkdownTextField
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import de.marquisproject.finotes.R
 import de.marquisproject.finotes.data.notes.model.NoteStatus
@@ -48,9 +48,9 @@ fun NoteScreen(
 ) {
     val viewModel: NoteViewModel = hiltViewModel()
 
-    val currentNote by viewModel.currentNote.collectAsState()
-    val currentBodyTextFieldValue by viewModel.currentBodyTextFieldValue.collectAsState()
-    val noteIsLoaded by viewModel.noteIsLoaded.collectAsState()
+    val currentNote by viewModel.currentNote.collectAsStateWithLifecycle()
+    val currentBodyTextFieldValue by viewModel.currentBodyTextFieldValue.collectAsStateWithLifecycle()
+    val noteIsLoaded by viewModel.noteIsLoaded.collectAsStateWithLifecycle()
     val bodyFocusRequester = remember { FocusRequester() }
     val openFinalDeleteAlert = remember { mutableStateOf(false) }
 

--- a/app/src/main/java/de/marquisproject/finotes/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/de/marquisproject/finotes/ui/screens/SettingsScreen.kt
@@ -23,10 +23,11 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import de.marquisproject.finotes.ui.theme.ThemeVariant
 import de.marquisproject.finotes.ui.theme.ThemeVariantMap
@@ -38,7 +39,7 @@ fun SettingsScreen(
     navController: NavController,
     viewModel: SettingsViewModel,
 ) {
-    val themeVariant = viewModel.themeVariant.collectAsState()
+    val themeVariant by viewModel.themeVariant.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {
@@ -77,7 +78,7 @@ fun SettingsScreen(
                         .fillMaxWidth()
                         .padding(8.dp)
                         .selectable(
-                            selected = themeVariant.value == themeV,
+                            selected = themeVariant == themeV,
                             onClick = {
                                 viewModel.saveThemeVariant(themeV)
                             }
@@ -93,7 +94,7 @@ fun SettingsScreen(
                             ?: (themeV.name.lowercase().replaceFirstChar { it.uppercase() } + "'s theme")
                         //val themename = themeV.name.lowercase().replaceFirstChar { it.uppercase() } + "'s theme"
                         RadioButton(
-                            selected = themeVariant.value == themeV,
+                            selected = themeVariant == themeV,
                             onClick = null
                         )
                         Text(


### PR DESCRIPTION
Use `val themeVariant by settingsViewModel.themeVariant.collectAsStateWithLifecycle()` rather than `val themeVariant = settingsViewModel.themeVariant.collectAsState()` to make the project consistent. This is also more modern and best practice since this makes the state collection lifecycle aware.