### PR TITLE
feat: transition to state based textfields in the notes screen

### DIFF
--- a/app/src/main/java/de/marquisproject/finotes/ui/components/MarkdownTextField.kt
+++ b/app/src/main/java/de/marquisproject/finotes/ui/components/MarkdownTextField.kt
@@ -2,7 +2,6 @@ package de.marquisproject.finotes.ui.components
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.MaterialTheme
@@ -34,7 +33,13 @@ fun MarkdownTextField(
     }
 
     val markdownOutputTransformation = remember(markerColor) {
+        // as long as marker color does not change, the output transformation is remembered
+        // through re-composition which is good for performance
         MarkdownUtils.getMarkdownOutputTransformation(markerColor)
+    }
+    val inputTransformation = remember {
+        // this will be remembered once because inside is just a lambda which does not change
+        MarkdownUtils.getListLogicInputTransformation()
     }
 
     TextField(
@@ -58,8 +63,6 @@ fun MarkdownTextField(
             disabledIndicatorColor = Color.Transparent,
             disabledContainerColor = Color.Transparent
         ),
-        inputTransformation = InputTransformation {
-            MarkdownUtils.handleListInput(this)
-        }
+        inputTransformation = inputTransformation
     )
 }

--- a/app/src/main/java/de/marquisproject/finotes/ui/components/MarkdownTextField.kt
+++ b/app/src/main/java/de/marquisproject/finotes/ui/components/MarkdownTextField.kt
@@ -20,8 +20,8 @@ import de.marquisproject.finotes.utils.MarkdownUtils
 
 @Composable
 fun MarkdownTextField(
-    state: TextFieldState = rememberTextFieldState(),
     modifier: Modifier = Modifier,
+    state: TextFieldState = rememberTextFieldState(),
     placeholder: @Composable (() -> Unit)? = null,
     textStyle: TextStyle = MaterialTheme.typography.bodyLarge,
     focusRequester: FocusRequester = remember { FocusRequester() },
@@ -46,7 +46,7 @@ fun MarkdownTextField(
         outputTransformation = markdownOutputTransformation,
         keyboardOptions = KeyboardOptions(
             imeAction = ImeAction.Default,
-            autoCorrectEnabled = false
+            autoCorrectEnabled = true
         ),
         placeholder = placeholder,
         readOnly = readOnly,

--- a/app/src/main/java/de/marquisproject/finotes/ui/components/MarkdownTextField.kt
+++ b/app/src/main/java/de/marquisproject/finotes/ui/components/MarkdownTextField.kt
@@ -2,6 +2,9 @@ package de.marquisproject.finotes.ui.components
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -11,27 +14,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onKeyEvent
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.OffsetMapping
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.text.input.TransformedText
-import androidx.compose.ui.text.input.VisualTransformation
-import androidx.compose.ui.text.style.TextDecoration
 import de.marquisproject.finotes.utils.MarkdownUtils
 
 @Composable
 fun MarkdownTextField(
-    value: TextFieldValue,
-    onValueChange: (TextFieldValue) -> Unit,
+    state: TextFieldState = rememberTextFieldState(),
     modifier: Modifier = Modifier,
     placeholder: @Composable (() -> Unit)? = null,
     textStyle: TextStyle = MaterialTheme.typography.bodyLarge,
@@ -44,42 +33,20 @@ fun MarkdownTextField(
             ?: onBackground).copy(alpha = 0.35f)
     }
 
+    val markdownOutputTransformation = remember(markerColor) {
+        MarkdownUtils.getMarkdownOutputTransformation(markerColor)
+    }
+
     TextField(
-        value = value,
-        onValueChange = { newValue ->
-            when {
-                // Handle Enter key (newline added)
-                newValue.text.length > value.text.length && 
-                newValue.text.getOrNull(newValue.selection.start - 1) == '\n' -> {
-                    onValueChange(MarkdownUtils.handleEnterKey(newValue))
-                }
-                // Handle Backspace (text length decreased)
-                newValue.text.length < value.text.length -> {
-                    onValueChange(MarkdownUtils.handleBackspace(value, newValue))
-                }
-                else -> onValueChange(newValue)
-            }
-        },
+        state = state,
         modifier = modifier
             .fillMaxWidth()
-            .focusRequester(focusRequester)
-            .onKeyEvent { keyEvent ->
-                // Hardware Enter key handling (before newline is added)
-                // Note: Backspace is handled in onValueChange rather than onKeyEvent
-                // because onValueChange is more reliable across different keyboard IMEs
-                if (keyEvent.key == Key.Enter) {
-                    val processedValue = MarkdownUtils.handleEnterKey(value)
-                    if (processedValue != value) {
-                        onValueChange(processedValue)
-                        return@onKeyEvent true
-                    }
-                }
-                false
-            },
+            .focusRequester(focusRequester),
         textStyle = textStyle,
-        visualTransformation = remember(markerColor) { MarkdownVisualTransformation(markerColor) },
+        outputTransformation = markdownOutputTransformation,
         keyboardOptions = KeyboardOptions(
-            imeAction = ImeAction.Default
+            imeAction = ImeAction.Default,
+            autoCorrectEnabled = false
         ),
         placeholder = placeholder,
         readOnly = readOnly,
@@ -90,46 +57,9 @@ fun MarkdownTextField(
             unfocusedContainerColor = Color.Transparent,
             disabledIndicatorColor = Color.Transparent,
             disabledContainerColor = Color.Transparent
-        )
-    )
-}
-
-/**
- * VisualTransformation that applies WhatsApp-style formatting (bold, italic, strikethrough)
- * while keeping the Markdown symbols visible but faded.
- */
-class MarkdownVisualTransformation(private val markerColor: Color) : VisualTransformation {
-    
-    override fun filter(text: AnnotatedString): TransformedText {
-        val annotatedString = buildAnnotatedString {
-            val rawText = text.text
-            append(rawText)
-
-            // Bold: *text* or **text**
-            MarkdownUtils.BOLD_REGEX.findAll(rawText).forEach { match ->
-                val prefix = match.groups[1]!!
-                addStyle(SpanStyle(fontWeight = FontWeight.Bold), match.range.first, match.range.last + 1)
-                addStyle(SpanStyle(color = markerColor), prefix.range.first, prefix.range.last + 1)
-                addStyle(SpanStyle(color = markerColor), match.range.last - prefix.value.length + 1, match.range.last + 1)
-            }
-
-            // Italic: _text_
-            MarkdownUtils.ITALIC_REGEX.findAll(rawText).forEach { match ->
-                val prefix = match.groups[1]!!
-                addStyle(SpanStyle(fontStyle = FontStyle.Italic), match.range.first, match.range.last + 1)
-                addStyle(SpanStyle(color = markerColor), prefix.range.first, prefix.range.last + 1)
-                addStyle(SpanStyle(color = markerColor), match.range.last, match.range.last + 1)
-            }
-
-            // Strikethrough: ~text~ or ~~text~~
-            MarkdownUtils.STRIKETHROUGH_REGEX.findAll(rawText).forEach { match ->
-                val prefix = match.groups[1]!!
-                addStyle(SpanStyle(textDecoration = TextDecoration.LineThrough), match.range.first, match.range.last + 1)
-                addStyle(SpanStyle(color = markerColor), prefix.range.first, prefix.range.last + 1)
-                addStyle(SpanStyle(color = markerColor), match.range.last - prefix.value.length + 1, match.range.last + 1)
-            }
+        ),
+        inputTransformation = InputTransformation {
+            MarkdownUtils.handleListInput(this)
         }
-
-        return TransformedText(annotatedString, OffsetMapping.Identity)
-    }
+    )
 }

--- a/app/src/main/java/de/marquisproject/finotes/ui/screens/NoteScreen.kt
+++ b/app/src/main/java/de/marquisproject/finotes/ui/screens/NoteScreen.kt
@@ -6,8 +6,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Delete
@@ -49,7 +49,6 @@ fun NoteScreen(
     val viewModel: NoteViewModel = hiltViewModel()
 
     val currentNote by viewModel.currentNote.collectAsStateWithLifecycle()
-    val currentBodyTextFieldValue by viewModel.currentBodyTextFieldValue.collectAsStateWithLifecycle()
     val noteIsLoaded by viewModel.noteIsLoaded.collectAsStateWithLifecycle()
     val bodyFocusRequester = remember { FocusRequester() }
     val openFinalDeleteAlert = remember { mutableStateOf(false) }
@@ -182,18 +181,17 @@ fun NoteScreen(
             ) {
                 TextField(
                     readOnly = currentNote.noteStatus != NoteStatus.ACTIVE && noteIsLoaded,
-                    value = currentNote.title,
-                    onValueChange = { viewModel.updateCurrentNoteTitle(it) },
+                    state = viewModel.titleState,
                     textStyle = MaterialTheme.typography.titleLarge.copy(color = MaterialTheme.colorScheme.onBackground),
                     modifier = Modifier
                         .fillMaxWidth(),
                     keyboardOptions = KeyboardOptions(
                         imeAction = androidx.compose.ui.text.input.ImeAction.Next,
                     ),
-                    keyboardActions = KeyboardActions(
-                        onNext = { bodyFocusRequester.requestFocus() },
-                    ),
-                    singleLine = true,
+                    onKeyboardAction = {
+                        bodyFocusRequester.requestFocus()
+                    },
+                    lineLimits = TextFieldLineLimits.SingleLine,
                     placeholder = { Text("Title", color = Color.Gray, style = MaterialTheme.typography.titleLarge) },
                     colors = TextFieldDefaults.colors(
                         focusedIndicatorColor = Color.Transparent,
@@ -206,8 +204,7 @@ fun NoteScreen(
                 )
                 MarkdownTextField(
                     readOnly = currentNote.noteStatus != NoteStatus.ACTIVE && noteIsLoaded,
-                    value = currentBodyTextFieldValue,
-                    onValueChange = { viewModel.updateCurrentNoteBody(it) },
+                    state = viewModel.bodyState,
                     textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onBackground),
                     focusRequester = bodyFocusRequester,
                     placeholder = {

--- a/app/src/main/java/de/marquisproject/finotes/ui/viewmodels/NoteViewModel.kt
+++ b/app/src/main/java/de/marquisproject/finotes/ui/viewmodels/NoteViewModel.kt
@@ -1,7 +1,9 @@
 package de.marquisproject.finotes.ui.viewmodels
 
 import android.util.Log
-import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -33,9 +35,9 @@ class NoteViewModel @Inject constructor(
 ) : ViewModel() {
     private val _noteIsLoaded = MutableStateFlow(false)
     private val _currentNote = MutableStateFlow(Note())
-    private val _currentBodyTextFieldValue = MutableStateFlow(TextFieldValue())
+    val titleState = TextFieldState()
+    val bodyState = TextFieldState()
 
-    val currentBodyTextFieldValue: StateFlow<TextFieldValue> = _currentBodyTextFieldValue.asStateFlow()
     val currentNote: StateFlow<Note> = _currentNote.asStateFlow()
     val noteIsLoaded: StateFlow<Boolean> = _noteIsLoaded.asStateFlow()
 
@@ -53,10 +55,25 @@ class NoteViewModel @Inject constructor(
             }
 
             _currentNote.update { note }
-            _currentBodyTextFieldValue.value = TextFieldValue(text = note.body)
+            titleState.setTextAndPlaceCursorAtEnd(note.title)
+            bodyState.setTextAndPlaceCursorAtEnd(note.body)
             _noteIsLoaded.value = true
 
             Log.d("NoteViewModel", "Note loaded: ${note.id}")
+        }
+
+        // Update _currentNote when states change
+        viewModelScope.launch {
+            snapshotFlow { titleState.text }
+                .collect { newText ->
+                    _currentNote.update { it.copy(title = newText.toString()) }
+                }
+        }
+        viewModelScope.launch {
+            snapshotFlow { bodyState.text }
+                .collect { newText ->
+                    _currentNote.update { it.copy(body = newText.toString()) }
+                }
         }
 
         // Debounce mechanism for saving the _currentNote
@@ -103,15 +120,6 @@ class NoteViewModel @Inject constructor(
     }
 
     // UI-facing update functions that directly modify _currentNote
-    fun updateCurrentNoteTitle(title: String) {
-        _currentNote.update { it.copy(title = title) }
-    }
-
-    fun updateCurrentNoteBody(newTextFieldValue: TextFieldValue) {
-        _currentBodyTextFieldValue.update { newTextFieldValue }
-        _currentNote.update { it.copy(body = newTextFieldValue.text) }
-    }
-
     fun updateCurrentNoteIsPinned(isPinned: Boolean) {
         _currentNote.update { it.copy(isPinned = isPinned) }
     }

--- a/app/src/main/java/de/marquisproject/finotes/ui/viewmodels/NoteViewModel.kt
+++ b/app/src/main/java/de/marquisproject/finotes/ui/viewmodels/NoteViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -62,17 +63,21 @@ class NoteViewModel @Inject constructor(
             Log.d("NoteViewModel", "Note loaded: ${note.id}")
         }
 
-        // Update _currentNote when states change
+        // Update _currentNote when states change efficiently
         viewModelScope.launch {
             snapshotFlow { titleState.text }
+                .map { it.toString() }
+                .distinctUntilChanged()
                 .collect { newText ->
-                    _currentNote.update { it.copy(title = newText.toString()) }
+                    _currentNote.update { it.copy(title = newText) }
                 }
         }
         viewModelScope.launch {
             snapshotFlow { bodyState.text }
+                .map { it.toString() }
+                .distinctUntilChanged()
                 .collect { newText ->
-                    _currentNote.update { it.copy(body = newText.toString()) }
+                    _currentNote.update { it.copy(body = newText) }
                 }
         }
 

--- a/app/src/main/java/de/marquisproject/finotes/utils/MarkdownUtils.kt
+++ b/app/src/main/java/de/marquisproject/finotes/utils/MarkdownUtils.kt
@@ -1,5 +1,6 @@
 package de.marquisproject.finotes.utils
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.text.input.OutputTransformation
 import androidx.compose.foundation.text.input.TextFieldBuffer
 import androidx.compose.foundation.text.input.delete
@@ -23,51 +24,61 @@ object MarkdownUtils {
     /**
      * Handles list formatting in a TextFieldBuffer for the new TextFieldState API.
      */
+    @OptIn(ExperimentalFoundationApi::class)
     fun handleListInput(buffer: TextFieldBuffer) {
         val text = buffer.asCharSequence()
         val selection = buffer.selection
 
         if (!selection.collapsed) return
 
-        // 1. Handle Newline (Enter key)
-        // We only trigger this if the text length increased and the last character added was a newline
-        if (buffer.length > buffer.originalText.length && selection.start > 0 && text[selection.start - 1] == '\n') {
-            val lineEnd = selection.start - 1
-            val lastNewLine = if (lineEnd == 0) -1 else text.lastIndexOf('\n', lineEnd - 1)
-            val lineStart = if (lastNewLine == -1) 0 else lastNewLine + 1
-            
-            val previousLine = text.substring(lineStart, lineEnd)
-            val bulletMatch = BULLET_PREFIX_REGEX.find(previousLine)
-            
-            if (bulletMatch != null) {
-                val indent = bulletMatch.groups[1]?.value ?: ""
-                val symbol = bulletMatch.groups[2]?.value ?: "-"
+        val changes = buffer.changes
+        // Only handle single-character changes to avoid interfering with pastes/multi-edits
+        if (changes.changeCount == 1) {
+            val changeRange = changes.getRange(0)
+            val originalRange = changes.getOriginalRange(0)
+
+            // 1. Handle Newline (Enter key)
+            if (changeRange.length == 1 && originalRange.length == 0 && (text.getOrNull(changeRange.start) == '\n')) {
+                val lineEnd = changeRange.start
+                val lastNewLine = if (lineEnd == 0) -1 else text.lastIndexOf('\n', lineEnd - 1)
+                val lineStart = if (lastNewLine == -1) 0 else lastNewLine + 1
                 
-                if (previousLine.trim() == symbol) {
-                    buffer.delete(lineStart, selection.start)
-                } else {
-                    buffer.insert(selection.start, "$indent$symbol ")
+                val previousLine = text.substring(lineStart, lineEnd)
+                val bulletMatch = BULLET_PREFIX_REGEX.find(previousLine)
+                
+                if (bulletMatch != null) {
+                    val indent = bulletMatch.groups[1]?.value ?: ""
+                    val symbol = bulletMatch.groups[2]?.value ?: "-"
+                    
+                    if (previousLine.trim() == symbol) {
+                        // User pressed enter on an empty bullet line: remove the bullet and end the list
+                        buffer.delete(lineStart, changeRange.end)
+                    } else {
+                        // Continue the list with the same indent and symbol
+                        buffer.insert(changeRange.end, "$indent$symbol ")
+                    }
                 }
+                return
             }
-            return // Enter handled, stop here
-        }
-        
-        // 2. Handle Backspace (Ported from handleBackspace)
-        if (buffer.length < buffer.originalText.length) {
-            val lineStart = if (selection.start <= 0) 0 else {
-                text.lastIndexOf('\n', selection.start - 1).let { if (it == -1) 0 else it + 1 }
-            }
-            val currentLine = text.substring(lineStart, selection.start)
-            val originalText = buffer.originalText
-            
-            // Safety check for indices
-            if (lineStart >= originalText.length) return
-            
-            val wasBullet = BULLET_PREFIX_REGEX.find(originalText.substring(lineStart)) != null
-            val isJustSymbol = Regex("^(\\s*)([-*])$").matches(currentLine)
-            
-            if (wasBullet && isJustSymbol) {
-                buffer.delete(lineStart, selection.start)
+
+            // 2. Handle Backspace (Ported from handleBackspace)
+            // Triggers if a single character was deleted and we are now left with just a symbol
+            if (changeRange.length == 0 && originalRange.length == 1) {
+                val lineStart = if (selection.start <= 0) 0 else {
+                    text.lastIndexOf('\n', selection.start - 1).let { if (it == -1) 0 else it + 1 }
+                }
+                val currentLine = text.substring(lineStart, selection.start)
+                val originalText = buffer.originalText
+                
+                // Safety check for indices against original text
+                if (lineStart >= originalText.length) return
+                
+                val wasBullet = BULLET_PREFIX_REGEX.find(originalText.substring(lineStart)) != null
+                val isJustSymbol = Regex("^(\\s*)([-*])$").matches(currentLine)
+                
+                if (wasBullet && isJustSymbol) {
+                    buffer.delete(lineStart, selection.start)
+                }
             }
         }
     }

--- a/app/src/main/java/de/marquisproject/finotes/utils/MarkdownUtils.kt
+++ b/app/src/main/java/de/marquisproject/finotes/utils/MarkdownUtils.kt
@@ -1,6 +1,7 @@
 package de.marquisproject.finotes.utils
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.OutputTransformation
 import androidx.compose.foundation.text.input.TextFieldBuffer
 import androidx.compose.foundation.text.input.delete
@@ -20,6 +21,7 @@ object MarkdownUtils {
     val STRIKETHROUGH_REGEX = Regex("(~{1,2})(.*?)\\1")
 
     private val BULLET_PREFIX_REGEX = Regex("^(\\s*)([-*])\\s")
+    private val JUST_SYMBOL_REGEX = Regex("^(\\s*)([-*])$")
 
     /**
      * Handles list formatting in a TextFieldBuffer for the new TextFieldState API.
@@ -29,6 +31,8 @@ object MarkdownUtils {
         val text = buffer.asCharSequence()
         val selection = buffer.selection
 
+        // return and exit if a selection is present. List logic should only be applied
+        // when a user types normally with no selection.
         if (!selection.collapsed) return
 
         val changes = buffer.changes
@@ -62,7 +66,7 @@ object MarkdownUtils {
             }
 
             // 2. Handle Backspace (Ported from handleBackspace)
-            // Triggers if a single character was deleted and we are now left with just a symbol
+            // Triggers if a single character was deleted, and we are now left with just a symbol
             if (changeRange.length == 0 && originalRange.length == 1) {
                 val lineStart = if (selection.start <= 0) 0 else {
                     text.lastIndexOf('\n', selection.start - 1).let { if (it == -1) 0 else it + 1 }
@@ -73,8 +77,12 @@ object MarkdownUtils {
                 // Safety check for indices against original text
                 if (lineStart >= originalText.length) return
                 
-                val wasBullet = BULLET_PREFIX_REGEX.find(originalText.substring(lineStart)) != null
-                val isJustSymbol = Regex("^(\\s*)([-*])$").matches(currentLine)
+                // Optimize wasBullet check to avoid large substring allocations
+                val lineEndInOriginal = originalText.indexOf('\n', lineStart).let {
+                    if (it == -1) originalText.length else it
+                }
+                val wasBullet = BULLET_PREFIX_REGEX.find(originalText.substring(lineStart, lineEndInOriginal)) != null
+                val isJustSymbol = JUST_SYMBOL_REGEX.matches(currentLine)
                 
                 if (wasBullet && isJustSymbol) {
                     buffer.delete(lineStart, selection.start)
@@ -84,7 +92,21 @@ object MarkdownUtils {
     }
 
     /**
+     * Returns an InputTransformation that handles Markdown list formatting.
+     *
+     * @return An InputTransformation that handles Markdown list formatting.
+     */
+    fun getListLogicInputTransformation(): InputTransformation {
+        return InputTransformation {
+            handleListInput(this)
+        }
+    }
+
+    /**
      * Applies Markdown styling to the visual output of a TextField.
+     *
+     * @param markerColor The color to use for the markers.
+     * @return An OutputTransformation that applies Markdown styling.
      */
     fun getMarkdownOutputTransformation(markerColor: Color): OutputTransformation {
         return OutputTransformation {

--- a/app/src/main/java/de/marquisproject/finotes/utils/MarkdownUtils.kt
+++ b/app/src/main/java/de/marquisproject/finotes/utils/MarkdownUtils.kt
@@ -1,12 +1,15 @@
 package de.marquisproject.finotes.utils
 
+import androidx.compose.foundation.text.input.OutputTransformation
+import androidx.compose.foundation.text.input.TextFieldBuffer
+import androidx.compose.foundation.text.input.delete
+import androidx.compose.foundation.text.input.insert
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextDecoration
 
 object MarkdownUtils {
@@ -18,108 +21,82 @@ object MarkdownUtils {
     private val BULLET_PREFIX_REGEX = Regex("^(\\s*)([-*])\\s")
 
     /**
-     * Handles the enter key to continue or terminate list formatting.
-     * Works both when triggered by a hardware key event (before newline is added)
-     * or by a change event (after newline is added).
+     * Handles list formatting in a TextFieldBuffer for the new TextFieldState API.
      */
-    fun handleEnterKey(currentValue: TextFieldValue): TextFieldValue {
-        val selection = currentValue.selection
-        val text = currentValue.text
-        
-        if (selection.start < 0) return currentValue.copy(composition = null)
-        
-        // Determine if the newline is already present (triggered by onValueChange)
-        val isAfterNewline = selection.start > 0 && text.getOrNull(selection.start - 1) == '\n'
-        
-        val lineEnd = if (isAfterNewline) selection.start - 1 else selection.start
-        val lastNewLine = text.lastIndexOf('\n', lineEnd - 1)
-        val lineStart = if (lastNewLine == -1) 0 else lastNewLine + 1
-        
-        val previousLine = text.substring(lineStart, lineEnd)
-        
-        // Handle Bullet Lists (- or *)
-        val bulletMatch = BULLET_PREFIX_REGEX.find(previousLine)
-        if (bulletMatch != null) {
-            val indent = bulletMatch.groups[1]?.value ?: ""
-            val symbol = bulletMatch.groups[2]?.value ?: "-"
+    fun handleListInput(buffer: TextFieldBuffer) {
+        val text = buffer.asCharSequence()
+        val selection = buffer.selection
+
+        if (!selection.collapsed) return
+
+        // 1. Handle Newline (Enter key)
+        // We only trigger this if the text length increased and the last character added was a newline
+        if (buffer.length > buffer.originalText.length && selection.start > 0 && text[selection.start - 1] == '\n') {
+            val lineEnd = selection.start - 1
+            val lastNewLine = if (lineEnd == 0) -1 else text.lastIndexOf('\n', lineEnd - 1)
+            val lineStart = if (lastNewLine == -1) 0 else lastNewLine + 1
             
-            // If the line is empty (just the bullet and space), terminate the list
-            if (previousLine.trim() == symbol) {
-                val newText = text.substring(0, lineStart) + text.substring(selection.start)
-                return currentValue.copy(
-                    text = newText,
-                    selection = TextRange(lineStart),
-                    composition = null
-                )
+            val previousLine = text.substring(lineStart, lineEnd)
+            val bulletMatch = BULLET_PREFIX_REGEX.find(previousLine)
+            
+            if (bulletMatch != null) {
+                val indent = bulletMatch.groups[1]?.value ?: ""
+                val symbol = bulletMatch.groups[2]?.value ?: "-"
+                
+                if (previousLine.trim() == symbol) {
+                    buffer.delete(lineStart, selection.start)
+                } else {
+                    buffer.insert(selection.start, "$indent$symbol ")
+                }
             }
+            return // Enter handled, stop here
+        }
+        
+        // 2. Handle Backspace (Ported from handleBackspace)
+        if (buffer.length < buffer.originalText.length) {
+            val lineStart = if (selection.start <= 0) 0 else {
+                text.lastIndexOf('\n', selection.start - 1).let { if (it == -1) 0 else it + 1 }
+            }
+            val currentLine = text.substring(lineStart, selection.start)
+            val originalText = buffer.originalText
             
-            // Otherwise, continue the list on the new line
-            val newLinePrefix = (if (isAfterNewline) "" else "\n") + indent + symbol + " "
-            val newText = text.substring(0, selection.start) + newLinePrefix + text.substring(selection.start)
-            return currentValue.copy(
-                text = newText,
-                selection = TextRange(selection.start + newLinePrefix.length),
-                composition = null
-            )
+            // Safety check for indices
+            if (lineStart >= originalText.length) return
+            
+            val wasBullet = BULLET_PREFIX_REGEX.find(originalText.substring(lineStart)) != null
+            val isJustSymbol = Regex("^(\\s*)([-*])$").matches(currentLine)
+            
+            if (wasBullet && isJustSymbol) {
+                buffer.delete(lineStart, selection.start)
+            }
         }
-        
-        return currentValue.copy(composition = null)
     }
 
     /**
-     * Handles backspace to remove list formatting if the cursor is at the start of a list item.
+     * Applies Markdown styling to the visual output of a TextField.
      */
-    fun handleBackspace(oldValue: TextFieldValue, newValue: TextFieldValue): TextFieldValue {
-        // If it's not a deletion, just return the newValue
-        if (newValue.text.length >= oldValue.text.length) return newValue
-        
-        val selection = oldValue.selection
-        val text = oldValue.text
-        
-        // Only trigger if the cursor was collapsed and at a potential bullet position
-        if (!selection.collapsed || selection.start == 0) return newValue
-        
-        val lineStart = text.lastIndexOf('\n', selection.start - 1).let { if (it == -1) 0 else it + 1 }
-        val currentLine = text.substring(lineStart, selection.start)
-        
-        // If the user deleted the space of a "- " or "* " prefix, remove the whole prefix
-        if (currentLine.matches(BULLET_PREFIX_REGEX)) {
-            return newValue.copy(
-                text = text.substring(0, lineStart) + text.substring(selection.start),
-                selection = TextRange(lineStart),
-                composition = null
-            )
+    fun getMarkdownOutputTransformation(markerColor: Color): OutputTransformation {
+        return OutputTransformation {
+            val rawText = asCharSequence()
+            forEachMarkdownMatch(rawText) { style, fullRange, startMarker, endMarker ->
+                addStyle(style, fullRange.first, fullRange.last + 1)
+                addStyle(SpanStyle(color = markerColor), startMarker.first, startMarker.last + 1)
+                addStyle(SpanStyle(color = markerColor), endMarker.first, endMarker.last + 1)
+            }
         }
-        
-        return newValue
     }
 
     /**
-     * Renders markdown text into an AnnotatedString, applying styles and removing markers.
+     * Renders Markdown text into an AnnotatedString, applying styles and removing markers.
      */
     fun renderMarkdown(text: String): AnnotatedString {
         val markers = mutableListOf<IntRange>()
         val styles = mutableListOf<Pair<IntRange, SpanStyle>>()
 
-        BOLD_REGEX.findAll(text).forEach { match ->
-            val prefix = match.groups[1]!!
-            markers.add(prefix.range)
-            markers.add(IntRange(match.range.last - prefix.value.length + 1, match.range.last))
-            styles.add(match.range to SpanStyle(fontWeight = FontWeight.Bold))
-        }
-
-        ITALIC_REGEX.findAll(text).forEach { match ->
-            val prefix = match.groups[1]!!
-            markers.add(prefix.range)
-            markers.add(IntRange(match.range.last, match.range.last))
-            styles.add(match.range to SpanStyle(fontStyle = FontStyle.Italic))
-        }
-
-        STRIKETHROUGH_REGEX.findAll(text).forEach { match ->
-            val prefix = match.groups[1]!!
-            markers.add(prefix.range)
-            markers.add(IntRange(match.range.last - prefix.value.length + 1, match.range.last))
-            styles.add(match.range to SpanStyle(textDecoration = TextDecoration.LineThrough))
+        forEachMarkdownMatch(text) { style, fullRange, startMarker, endMarker ->
+            markers.add(startMarker)
+            markers.add(endMarker)
+            styles.add(fullRange to style)
         }
 
         val skip = BooleanArray(text.length)
@@ -148,6 +125,47 @@ object MarkdownUtils {
                     addStyle(style, start, end)
                 }
             }
+        }
+    }
+
+    /**
+     * Internal helper to unify the regex matching logic.
+     */
+    private fun forEachMarkdownMatch(
+        text: CharSequence,
+        action: (style: SpanStyle, fullRange: IntRange, startMarker: IntRange, endMarker: IntRange) -> Unit
+    ) {
+        // Bold: *text* or **text**
+        BOLD_REGEX.findAll(text).forEach { match ->
+            val prefix = match.groups[1]!!
+            action(
+                SpanStyle(fontWeight = FontWeight.Bold),
+                match.range,
+                prefix.range,
+                IntRange(match.range.last - prefix.value.length + 1, match.range.last)
+            )
+        }
+
+        // Italic: _text_
+        ITALIC_REGEX.findAll(text).forEach { match ->
+            val prefix = match.groups[1]!!
+            action(
+                SpanStyle(fontStyle = FontStyle.Italic),
+                match.range,
+                prefix.range,
+                IntRange(match.range.last, match.range.last)
+            )
+        }
+
+        // Strikethrough: ~text~ or ~~text~~
+        STRIKETHROUGH_REGEX.findAll(text).forEach { match ->
+            val prefix = match.groups[1]!!
+            action(
+                SpanStyle(textDecoration = TextDecoration.LineThrough),
+                match.range,
+                prefix.range,
+                IntRange(match.range.last - prefix.value.length + 1, match.range.last)
+            )
         }
     }
 }

--- a/app/src/test/java/de/marquisproject/finotes/utils/MarkdownUtilsTest.kt
+++ b/app/src/test/java/de/marquisproject/finotes/utils/MarkdownUtilsTest.kt
@@ -1,98 +1,143 @@
 package de.marquisproject.finotes.utils
 
+import androidx.compose.foundation.text.input.TextFieldBuffer
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.ui.text.TextRange
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 class MarkdownUtilsTest {
 
-    private fun testInputTransformation(initialText: String, initialSelection: TextRange, newText: String, newSelection: TextRange): TextFieldState {
+    /**
+     * Creates a TextFieldState with the given initial text and selection, and applies the given edit block to it as well as the list logic.
+     *
+     * @param initialText The initial text of the TextFieldState.
+     * @param initialSelection The initial selection of the TextFieldState.
+     * @param editBlock A lambda that will be applied to the TextFieldState to edit it.
+     * @return The edited TextFieldState.
+     */
+    private fun createStateAndEdit(
+        initialText: String,
+        initialSelection: TextRange,
+        editBlock: TextFieldBuffer.() -> Unit
+    ): TextFieldState {
         val state = TextFieldState(initialText, initialSelection)
-        state.edit {
-            // Simulate realistic typing by only inserting the difference
-            if (newText.length > initialText.length) {
-                val addedText = newText.substring(initialSelection.start, initialSelection.start + (newText.length - initialText.length))
-                replace(initialSelection.start, initialSelection.end, addedText)
-            } else if (newText.length < initialText.length) {
-                replace(newSelection.start, initialSelection.start, "")
-            }
-            selection = newSelection
-            MarkdownUtils.handleListInput(this)
-        }
+        state.edit { editBlock(); MarkdownUtils.handleListInput(this) }
         return state
     }
 
     @Test
     fun `handleListInput continues unordered list with dash`() {
-        val state = testInputTransformation("- item", TextRange(6), "- item\n", TextRange(7))
-        assertEquals("- item\n- ", state.text.toString())
-        assertEquals(TextRange(9), state.selection)
+        val testState = createStateAndEdit(
+            "- item",
+            TextRange(6),
+            editBlock = { append("\n") }
+        )
+        assertEquals("- item\n- ", testState.text.toString())
+        assertEquals(TextRange(9), testState.selection)
     }
 
     @Test
     fun `handleListInput continues unordered list with asterisk`() {
-        val state = testInputTransformation("* item", TextRange(6), "* item\n", TextRange(7))
-        assertEquals("* item\n* ", state.text.toString())
-        assertEquals(TextRange(9), state.selection)
+        val testState = createStateAndEdit(
+            "* item",
+            TextRange(6),
+            editBlock = { append("\n") }
+        )
+        assertEquals("* item\n* ", testState.text.toString())
+        assertEquals(TextRange(9), testState.selection)
     }
 
     @Test
     fun `handleListInput continues indented unordered list`() {
-        val state = testInputTransformation("  - item", TextRange(8), "  - item\n", TextRange(9))
-        assertEquals("  - item\n  - ", state.text.toString())
-        assertEquals(TextRange(13), state.selection)
+        val testState = createStateAndEdit(
+            "  - item",
+            TextRange(8),
+            editBlock = { append("\n") }
+        )
+        assertEquals("  - item\n  - ", testState.text.toString())
+        assertEquals(TextRange(13), testState.selection)
     }
 
     @Test
     fun `handleListInput removes empty list item`() {
-        val state = testInputTransformation("- ", TextRange(2), "- \n", TextRange(3))
-        assertEquals("", state.text.toString())
-        assertEquals(TextRange(0), state.selection)
+        val testState = createStateAndEdit(
+            "- ",
+            TextRange(2),
+            editBlock = { append("\n") }
+        )
+        assertEquals("", testState.text.toString())
+        assertEquals(TextRange(0), testState.selection)
     }
 
     @Test
     fun `handleListInput removes indented empty list item`() {
-        val state = testInputTransformation("  - ", TextRange(4), "  - \n", TextRange(5))
-        assertEquals("", state.text.toString())
-        assertEquals(TextRange(0), state.selection)
+        val testState = createStateAndEdit(
+            "  - ",
+            TextRange(4),
+            editBlock = { append("\n") }
+        )
+        assertEquals("", testState.text.toString())
+        assertEquals(TextRange(0), testState.selection)
     }
 
     @Test
     fun `handleListInput splits list item and preserves suffix`() {
         // "- it|em" -> "- it\n- em"
-        val state = testInputTransformation("- item", TextRange(4), "- it\nem", TextRange(5))
-        assertEquals("- it\n- em", state.text.toString())
-        assertEquals(TextRange(7), state.selection)
+        val testState = createStateAndEdit(
+            "- item",
+            TextRange(4),
+            editBlock = {
+                // simulate cursor between t and e and press enter
+                replace(selection.start, selection.end, "\n")
+            }
+        )
+        assertEquals("- it\n- em", testState.text.toString())
+        assertEquals(TextRange(7), testState.selection)
     }
 
     @Test
     fun `handleListInput handles tab indentation`() {
-        val state = testInputTransformation("\t- item", TextRange(7), "\t- item\n", TextRange(8))
-        assertEquals("\t- item\n\t- ", state.text.toString())
-        assertEquals(TextRange(11), state.selection)
+        val testState = createStateAndEdit(
+            "\t- item",
+            TextRange(7),
+            editBlock = { append("\n") }
+        )
+        assertEquals("\t- item\n\t- ", testState.text.toString())
+        assertEquals(TextRange(11), testState.selection)
     }
 
     @Test
     fun `handleListInput does nothing when enter is pressed at very start of bullet line`() {
         // "|- item" -> "\n- item" (should not auto-bullet the new empty line above)
-        val state = testInputTransformation("- item", TextRange(0), "\n- item", TextRange(1))
-        assertEquals("\n- item", state.text.toString())
-        assertEquals(TextRange(1), state.selection)
+        val testState = createStateAndEdit(
+            "- item",
+            TextRange(0),
+            editBlock = { replace(selection.start, selection.end, "\n") }
+        )
+        assertEquals("\n- item", testState.text.toString())
+        assertEquals(TextRange(1), testState.selection)
     }
 
     @Test
     fun `handleListInput allows multiple newlines to break list`() {
         // If we are at "- item\n- " and press enter again, it should clear the bullet (covered by empty list item test)
         // But what if we are at "- item\n" and press enter?
-        val state = testInputTransformation("- item\n", TextRange(7), "- item\n\n", TextRange(8))
+        val state = createStateAndEdit(
+            "- item\n",
+            TextRange(7),
+            editBlock = { append("\n") }
+        )
         assertEquals("- item\n\n", state.text.toString())
     }
 
     @Test
     fun `handleListInput does nothing on regular text`() {
-        val state = testInputTransformation("Regular text", TextRange(12), "Regular text\n", TextRange(13))
+        val state = createStateAndEdit(
+            "Regular text",
+            TextRange(12),
+            editBlock = { append("\n") }
+        )
         assertEquals("Regular text\n", state.text.toString())
         assertEquals(TextRange(13), state.selection)
     }
@@ -100,105 +145,56 @@ class MarkdownUtilsTest {
     @Test
     fun `handleListInput does not get confused by dash in middle of text`() {
         // "Some - text" -> Enter -> "Some - text\n" (Should not auto-bullet)
-        val state = testInputTransformation("Some - text", TextRange(11), "Some - text\n", TextRange(12))
+        val state = createStateAndEdit(
+            "Some - text",
+            TextRange(11),
+            editBlock = { append("\n") }
+        )
         assertEquals("Some - text\n", state.text.toString())
         assertEquals(TextRange(12), state.selection)
     }
 
     @Test
     fun `handleListInput ignores fake bullet without trailing space`() {
-        // "-Text" is not a markdown list item. " -Text\n" should not trigger.
-        val state = testInputTransformation("-Text", TextRange(5), "-Text\n", TextRange(6))
+        // "-Text" is not a Markdown list item. " -Text\n" should not trigger.
+        val state = createStateAndEdit(
+            "-Text",
+            TextRange(5),
+            editBlock = { append("\n") }
+        )
         assertEquals("-Text\n", state.text.toString())
     }
 
     @Test
-    fun `handleListInput preserves the specific bullet symbol used`() {
-        // Asterisk should continue with asterisk
-        val asteriskState = testInputTransformation("* item", TextRange(6), "* item\n", TextRange(7))
-        assertEquals("* item\n* ", asteriskState.text.toString())
-
-        // Dash should continue with dash
-        val dashState = testInputTransformation("- item", TextRange(6), "- item\n", TextRange(7))
-        assertEquals("- item\n- ", dashState.text.toString())
-    }
-
-    @Test
-    fun `handleListInput handles already indented text after newline`() {
-        // If the user somehow already has indentation on the new line, we should still behave correctly
-        val state = TextFieldState("- item\n  ", TextRange(9))
-        state.edit {
-            MarkdownUtils.handleListInput(this)
-        }
-        // This is a bit of an edge case for the current implementation which expects to be called immediately after \n
-        // But it's good to ensure it doesn't crash or do something wild.
-        assertEquals("- item\n  ", state.text.toString())
-    }
-
-    @Test
-    fun `handleListInput does nothing when cursor simply moves to line after list`() {
-        // Text ends with a list item and a newline, but the edit didn't JUST add that newline
-        val state = TextFieldState("- item\n", TextRange(7))
-        state.edit {
-            // No changes, just calling the handler
-            MarkdownUtils.handleListInput(this)
-        }
-        assertEquals("- item\n", state.text.toString())
-        assertEquals(TextRange(7), state.selection)
-    }
-
-    @Test
     fun `handleListInput removes bullet on backspace`() {
-        val state = TextFieldState("- item", TextRange(2))
-        state.edit {
-            replace(1, 2, "") // Delete space
-            MarkdownUtils.handleListInput(this)
-        }
+        val state = createStateAndEdit(
+            "- item",
+            TextRange(2),
+            editBlock = { replace(selection.start - 1, selection.end, "") }
+        )
         assertEquals("item", state.text.toString())
         assertEquals(TextRange(0), state.selection)
     }
 
     @Test
     fun `handleListInput removes indented bullet on backspace`() {
-        val state = TextFieldState("  - item", TextRange(4))
-        state.edit {
-            replace(3, 4, "") // Delete space
-            MarkdownUtils.handleListInput(this)
-        }
+        val state = createStateAndEdit(
+            "  - item",
+            TextRange(4),
+            editBlock = { replace(selection.start - 1, selection.end, "") }
+        )
         assertEquals("item", state.text.toString())
         assertEquals(TextRange(0), state.selection)
     }
 
     @Test
     fun `handleListInput backspacing in middle of text does not trigger bullet removal`() {
-        val state = TextFieldState("- item", TextRange(4))
-        state.edit {
-            replace(3, 4, "") // Delete 't' -> "- iem"
-            MarkdownUtils.handleListInput(this)
-        }
+        val state = createStateAndEdit(
+            "- item",
+            TextRange(4),
+            editBlock = { replace(3, 4, "") }
+        )
         assertEquals("- iem", state.text.toString())
         assertEquals(TextRange(3), state.selection)
-    }
-
-    @Test
-    fun `bullet regex matches standard dash list`() {
-        val regex = Regex("^(\\s*)([-*])\\s")
-        val text = "- item"
-
-        val match = regex.find(text)
-        assertNotNull(match)
-        assertEquals("", match!!.groups[1]!!.value)
-        assertEquals("-", match.groups[2]!!.value)
-    }
-
-    @Test
-    fun `bullet regex matches indented list`() {
-        val regex = Regex("^(\\s*)([-*])\\s")
-        val text = "  * item"
-
-        val match = regex.find(text)
-        assertNotNull(match)
-        assertEquals("  ", match!!.groups[1]!!.value)
-        assertEquals("*", match.groups[2]!!.value)
     }
 }

--- a/app/src/test/java/de/marquisproject/finotes/utils/MarkdownUtilsTest.kt
+++ b/app/src/test/java/de/marquisproject/finotes/utils/MarkdownUtilsTest.kt
@@ -60,10 +60,79 @@ class MarkdownUtilsTest {
     }
 
     @Test
+    fun `handleListInput splits list item and preserves suffix`() {
+        // "- it|em" -> "- it\n- em"
+        val state = testInputTransformation("- item", TextRange(4), "- it\nem", TextRange(5))
+        assertEquals("- it\n- em", state.text.toString())
+        assertEquals(TextRange(7), state.selection)
+    }
+
+    @Test
+    fun `handleListInput handles tab indentation`() {
+        val state = testInputTransformation("\t- item", TextRange(7), "\t- item\n", TextRange(8))
+        assertEquals("\t- item\n\t- ", state.text.toString())
+        assertEquals(TextRange(11), state.selection)
+    }
+
+    @Test
+    fun `handleListInput does nothing when enter is pressed at very start of bullet line`() {
+        // "|- item" -> "\n- item" (should not auto-bullet the new empty line above)
+        val state = testInputTransformation("- item", TextRange(0), "\n- item", TextRange(1))
+        assertEquals("\n- item", state.text.toString())
+        assertEquals(TextRange(1), state.selection)
+    }
+
+    @Test
+    fun `handleListInput allows multiple newlines to break list`() {
+        // If we are at "- item\n- " and press enter again, it should clear the bullet (covered by empty list item test)
+        // But what if we are at "- item\n" and press enter?
+        val state = testInputTransformation("- item\n", TextRange(7), "- item\n\n", TextRange(8))
+        assertEquals("- item\n\n", state.text.toString())
+    }
+
+    @Test
     fun `handleListInput does nothing on regular text`() {
         val state = testInputTransformation("Regular text", TextRange(12), "Regular text\n", TextRange(13))
         assertEquals("Regular text\n", state.text.toString())
         assertEquals(TextRange(13), state.selection)
+    }
+
+    @Test
+    fun `handleListInput does not get confused by dash in middle of text`() {
+        // "Some - text" -> Enter -> "Some - text\n" (Should not auto-bullet)
+        val state = testInputTransformation("Some - text", TextRange(11), "Some - text\n", TextRange(12))
+        assertEquals("Some - text\n", state.text.toString())
+        assertEquals(TextRange(12), state.selection)
+    }
+
+    @Test
+    fun `handleListInput ignores fake bullet without trailing space`() {
+        // "-Text" is not a markdown list item. " -Text\n" should not trigger.
+        val state = testInputTransformation("-Text", TextRange(5), "-Text\n", TextRange(6))
+        assertEquals("-Text\n", state.text.toString())
+    }
+
+    @Test
+    fun `handleListInput preserves the specific bullet symbol used`() {
+        // Asterisk should continue with asterisk
+        val asteriskState = testInputTransformation("* item", TextRange(6), "* item\n", TextRange(7))
+        assertEquals("* item\n* ", asteriskState.text.toString())
+
+        // Dash should continue with dash
+        val dashState = testInputTransformation("- item", TextRange(6), "- item\n", TextRange(7))
+        assertEquals("- item\n- ", dashState.text.toString())
+    }
+
+    @Test
+    fun `handleListInput handles already indented text after newline`() {
+        // If the user somehow already has indentation on the new line, we should still behave correctly
+        val state = TextFieldState("- item\n  ", TextRange(9))
+        state.edit {
+            MarkdownUtils.handleListInput(this)
+        }
+        // This is a bit of an edge case for the current implementation which expects to be called immediately after \n
+        // But it's good to ensure it doesn't crash or do something wild.
+        assertEquals("- item\n  ", state.text.toString())
     }
 
     @Test
@@ -98,6 +167,17 @@ class MarkdownUtilsTest {
         }
         assertEquals("item", state.text.toString())
         assertEquals(TextRange(0), state.selection)
+    }
+
+    @Test
+    fun `handleListInput backspacing in middle of text does not trigger bullet removal`() {
+        val state = TextFieldState("- item", TextRange(4))
+        state.edit {
+            replace(3, 4, "") // Delete 't' -> "- iem"
+            MarkdownUtils.handleListInput(this)
+        }
+        assertEquals("- iem", state.text.toString())
+        assertEquals(TextRange(3), state.selection)
     }
 
     @Test

--- a/app/src/test/java/de/marquisproject/finotes/utils/MarkdownUtilsTest.kt
+++ b/app/src/test/java/de/marquisproject/finotes/utils/MarkdownUtilsTest.kt
@@ -11,7 +11,13 @@ class MarkdownUtilsTest {
     private fun testInputTransformation(initialText: String, initialSelection: TextRange, newText: String, newSelection: TextRange): TextFieldState {
         val state = TextFieldState(initialText, initialSelection)
         state.edit {
-            replace(0, length, newText)
+            // Simulate realistic typing by only inserting the difference
+            if (newText.length > initialText.length) {
+                val addedText = newText.substring(initialSelection.start, initialSelection.start + (newText.length - initialText.length))
+                replace(initialSelection.start, initialSelection.end, addedText)
+            } else if (newText.length < initialText.length) {
+                replace(newSelection.start, initialSelection.start, "")
+            }
             selection = newSelection
             MarkdownUtils.handleListInput(this)
         }

--- a/app/src/test/java/de/marquisproject/finotes/utils/MarkdownUtilsTest.kt
+++ b/app/src/test/java/de/marquisproject/finotes/utils/MarkdownUtilsTest.kt
@@ -129,6 +129,7 @@ class MarkdownUtilsTest {
             editBlock = { append("\n") }
         )
         assertEquals("- item\n\n", state.text.toString())
+        assertEquals(TextRange(8), state.selection)
     }
 
     @Test
@@ -163,6 +164,7 @@ class MarkdownUtilsTest {
             editBlock = { append("\n") }
         )
         assertEquals("-Text\n", state.text.toString())
+        assertEquals(TextRange(6), state.selection)
     }
 
     @Test

--- a/app/src/test/java/de/marquisproject/finotes/utils/MarkdownUtilsTest.kt
+++ b/app/src/test/java/de/marquisproject/finotes/utils/MarkdownUtilsTest.kt
@@ -1,335 +1,97 @@
 package de.marquisproject.finotes.utils
 
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.TextFieldValue
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MarkdownUtilsTest {
-    @Test
-    fun `handleEnterKey continues unordered list with dash`() {
-        // Note: handleEnterKey is called AFTER the newline is inserted by the IME
-        // So the input text already contains the newline character
-        val text = "- item\n"  // Newline already inserted
-        val selection = TextRange(7) // Cursor AFTER the newline (position 7)
-        val input = TextFieldValue(text, selection)
 
-        val result = MarkdownUtils.handleEnterKey(input)
-
-        assertEquals("- item\n- ", result.text)
-        assertEquals(TextRange(9), result.selection) // Cursor after "- " on new line
+    private fun testInputTransformation(initialText: String, initialSelection: TextRange, newText: String, newSelection: TextRange): TextFieldState {
+        val state = TextFieldState(initialText, initialSelection)
+        state.edit {
+            replace(0, length, newText)
+            selection = newSelection
+            MarkdownUtils.handleListInput(this)
+        }
+        return state
     }
 
     @Test
-    fun `handleEnterKey continues unordered list with asterisk`() {
-        val text = "* item\n"
-        val selection = TextRange(7) // Cursor after the newline
-        val input = TextFieldValue(text, selection)
-
-        val result = MarkdownUtils.handleEnterKey(input)
-
-        assertEquals("* item\n* ", result.text)
-        assertEquals(TextRange(9), result.selection)
+    fun `handleListInput continues unordered list with dash`() {
+        val state = testInputTransformation("- item", TextRange(6), "- item\n", TextRange(7))
+        assertEquals("- item\n- ", state.text.toString())
+        assertEquals(TextRange(9), state.selection)
     }
 
     @Test
-    fun `handleEnterKey continues indented unordered list`() {
-        val text = "  - item\n"
-        val selection = TextRange(9) // Cursor after the newline
-        val input = TextFieldValue(text, selection)
-
-        val result = MarkdownUtils.handleEnterKey(input)
-
-        assertEquals("  - item\n  - ", result.text)
-        assertEquals(TextRange(13), result.selection)
+    fun `handleListInput continues unordered list with asterisk`() {
+        val state = testInputTransformation("* item", TextRange(6), "* item\n", TextRange(7))
+        assertEquals("* item\n* ", state.text.toString())
+        assertEquals(TextRange(9), state.selection)
     }
 
     @Test
-    fun `handleEnterKey removes empty list item`() {
-        // "- \n" has length 3, with '\n' at index 2
-        val text = "- \n"
-        val selection = TextRange(3) // Cursor after the newline
-        val input = TextFieldValue(text, selection)
-
-        val result = MarkdownUtils.handleEnterKey(input)
-
-        assertEquals("", result.text)
-        assertEquals(TextRange(0), result.selection)
+    fun `handleListInput continues indented unordered list`() {
+        val state = testInputTransformation("  - item", TextRange(8), "  - item\n", TextRange(9))
+        assertEquals("  - item\n  - ", state.text.toString())
+        assertEquals(TextRange(13), state.selection)
     }
 
     @Test
-    fun `handleEnterKey removes indented empty list item`() {
-        // "  - \n" has length 5, with '\n' at index 4
-        val text = "  - \n"
-        val selection = TextRange(5) // Cursor after the newline
-        val input = TextFieldValue(text, selection)
-
-        val result = MarkdownUtils.handleEnterKey(input)
-
-        assertEquals("", result.text)
-        assertEquals(TextRange(0), result.selection)
+    fun `handleListInput removes empty list item`() {
+        val state = testInputTransformation("- ", TextRange(2), "- \n", TextRange(3))
+        assertEquals("", state.text.toString())
+        assertEquals(TextRange(0), state.selection)
     }
 
     @Test
-    fun `handleEnterKey does nothing on regular text`() {
-        val text = "Regular text"
-        val selection = TextRange(12)
-        val input = TextFieldValue(text, selection)
-
-        val result = MarkdownUtils.handleEnterKey(input)
-
-        // Should only clear composition, text unchanged
-        assertEquals("Regular text", result.text)
-        assertEquals(selection, result.selection)
+    fun `handleListInput removes indented empty list item`() {
+        val state = testInputTransformation("  - ", TextRange(4), "  - \n", TextRange(5))
+        assertEquals("", state.text.toString())
+        assertEquals(TextRange(0), state.selection)
     }
 
     @Test
-    fun `handleEnterKey does nothing on empty text`() {
-        val input = TextFieldValue("", TextRange(0))
-
-        val result = MarkdownUtils.handleEnterKey(input)
-
-        assertEquals("", result.text)
-        assertEquals(TextRange(0), result.selection)
+    fun `handleListInput does nothing on regular text`() {
+        val state = testInputTransformation("Regular text", TextRange(12), "Regular text\n", TextRange(13))
+        assertEquals("Regular text\n", state.text.toString())
+        assertEquals(TextRange(13), state.selection)
     }
 
     @Test
-    fun `handleEnterKey handles cursor in middle of line`() {
-        // "- it\nem" has length 6, with '\n' at index 4
-        val text = "- it\nem"  // User inserted newline in middle
-        val selection = TextRange(5) // Cursor after newline
-        val input = TextFieldValue(text, selection)
-
-        val result = MarkdownUtils.handleEnterKey(input)
-
-        // Should still continue the list based on previous line "- it"
-        assertEquals("- it\n- em", result.text)
-        // "- " has 2 characters, so selection is 5 + 2 = 7
-        assertEquals(TextRange(7), result.selection)
+    fun `handleListInput does nothing when cursor simply moves to line after list`() {
+        // Text ends with a list item and a newline, but the edit didn't JUST add that newline
+        val state = TextFieldState("- item\n", TextRange(7))
+        state.edit {
+            // No changes, just calling the handler
+            MarkdownUtils.handleListInput(this)
+        }
+        assertEquals("- item\n", state.text.toString())
+        assertEquals(TextRange(7), state.selection)
     }
 
     @Test
-    fun `handleEnterKey handles multiple newlines in text`() {
-        // "first line\n- item\n" has length 18, with '\n' at index 17
-        val text = "first line\n- item\n"
-        val selection = TextRange(18) // Cursor AFTER the newline (position 18)
-        val input = TextFieldValue(text, selection)
-
-        val result = MarkdownUtils.handleEnterKey(input)
-
-        assertEquals("first line\n- item\n- ", result.text)
-        // "- " has 2 characters, so selection is 18 + 2 = 20
-        assertEquals(TextRange(20), result.selection)
+    fun `handleListInput removes bullet on backspace`() {
+        val state = TextFieldState("- item", TextRange(2))
+        state.edit {
+            replace(1, 2, "") // Delete space
+            MarkdownUtils.handleListInput(this)
+        }
+        assertEquals("item", state.text.toString())
+        assertEquals(TextRange(0), state.selection)
     }
 
     @Test
-    fun `handleEnterKey preserves existing content after cursor`() {
-        val text = "- item\nafter"
-        val selection = TextRange(7) // Cursor right after newline (index 6 is '\n')
-        val input = TextFieldValue(text, selection)
-
-        val result = MarkdownUtils.handleEnterKey(input)
-
-        // Text after cursor should be preserved
-        assertEquals("- item\n- after", result.text)
-        // "- " has 2 characters, so selection is 7 + 2 = 9
-        assertEquals(TextRange(9), result.selection)
-    }
-
-    @Test
-    fun `handleEnterKey with only bullet symbol`() {
-        val text = "-"
-        val selection = TextRange(1)
-        val input = TextFieldValue(text, selection)
-
-        val result = MarkdownUtils.handleEnterKey(input)
-
-        // Single dash without space should not trigger list behavior
-        // based on the regex ^(\s*)([-*])\s which requires a space after the bullet
-        assertEquals("-", result.text)
-    }
-
-    @Test
-    fun `handleEnterKey with whitespace before bullet`() {
-        // "   - item\n" has length 11, with '\n' at index 10
-        val text = "   - item\n"
-        val selection = TextRange(10) // Cursor after the newline
-        val input = TextFieldValue(text, selection)
-
-        val result = MarkdownUtils.handleEnterKey(input)
-
-        assertEquals("   - item\n   - ", result.text)
-        // "   - " has 5 characters (3 spaces + dash + space), so selection is 11 + 5 = 16
-        assertEquals(TextRange(15), result.selection)
-    }
-
-    @Test
-    fun `handleEnterKey with asterisk and no space`() {
-        val text = "*item"  // No space after asterisk
-        val selection = TextRange(5)
-        val input = TextFieldValue(text, selection)
-
-        val result = MarkdownUtils.handleEnterKey(input)
-
-        // Should not match because regex requires space after bullet
-        assertEquals("*item", result.text)
-    }
-
-    @Test
-    fun `handleEnterKey with mixed bullet types`() {
-        // text = "- first\n* second\n" has length 17, with '\n' at index 16
-        val text = "- first\n* second\n"
-        val selection = TextRange(17) // Cursor AFTER the newline
-        val input = TextFieldValue(text, selection)
-
-        val result = MarkdownUtils.handleEnterKey(input)
-
-        // Should continue with the same bullet type as current line (*)
-        assertEquals("- first\n* second\n* ", result.text)
-        // "* " has 2 characters, so selection is 17 + 2 = 19
-        assertEquals(TextRange(19), result.selection)
-    }
-
-    @Test
-    fun `handleBackspace removes bullet when cursor at start of list item`() {
-        val oldValue = TextFieldValue("- item", TextRange(2))
-        val newValue = TextFieldValue("-item", TextRange(1))
-
-        val result = MarkdownUtils.handleBackspace(oldValue, newValue)
-
-        assertEquals("item", result.text)
-        assertEquals(TextRange(0), result.selection)
-    }
-
-    @Test
-    fun `handleBackspace does nothing when not in list`() {
-        val oldValue = TextFieldValue("Regular text", TextRange(8))
-        val newValue = TextFieldValue("Regulartext", TextRange(7))
-
-        val result = MarkdownUtils.handleBackspace(oldValue, newValue)
-
-        assertEquals(newValue.text, result.text)
-        assertEquals(newValue.selection, result.selection)
-    }
-
-    @Test
-    fun `handleBackspace does nothing at start of text`() {
-        val oldValue = TextFieldValue("- item", TextRange(0))
-        val newValue = TextFieldValue("- item", TextRange(0)) // No change possible
-
-        val result = MarkdownUtils.handleBackspace(oldValue, newValue)
-
-        assertEquals(oldValue.text, result.text)
-        assertEquals(oldValue.selection, result.selection)
-    }
-
-    @Test
-    fun `handleBackspace does nothing with selection`() {
-        val oldValue = TextFieldValue("- item", TextRange(2, 5))
-        val newValue = TextFieldValue("- ", TextRange(2)) // Deletion of "item"
-
-        val result = MarkdownUtils.handleBackspace(oldValue, newValue)
-
-        // Should not handle when selection is not collapsed in oldValue
-        assertEquals(newValue.text, result.text)
-    }
-
-    @Test
-    fun `handleBackspace removes indented bullet`() {
-        val oldValue = TextFieldValue("  - item", TextRange(4))
-        val newValue = TextFieldValue("  -item", TextRange(3))
-
-        val result = MarkdownUtils.handleBackspace(oldValue, newValue)
-
-        assertEquals("item", result.text)
-        assertEquals(TextRange(0), result.selection)
-    }
-
-    @Test
-    fun `handleBackspace removes asterisk bullet`() {
-        val oldValue = TextFieldValue("* item", TextRange(2))
-        val newValue = TextFieldValue("*item", TextRange(1))
-
-        val result = MarkdownUtils.handleBackspace(oldValue, newValue)
-
-        assertEquals("item", result.text)
-        assertEquals(TextRange(0), result.selection)
-    }
-
-    @Test
-    fun `handleBackspace with partial bullet match at cursor`() {
-        val oldValue = TextFieldValue("-item", TextRange(1))
-        val newValue = TextFieldValue("item", TextRange(0))
-
-        val result = MarkdownUtils.handleBackspace(oldValue, newValue)
-
-        // Should not match because there's no space after the bullet in oldValue
-        assertEquals("item", result.text)
-    }
-
-    @Test
-    fun `handleBackspace with bullet in middle of line`() {
-        val oldValue = TextFieldValue("text - item", TextRange(7))
-        val newValue = TextFieldValue("text -item", TextRange(6))
-
-        val result = MarkdownUtils.handleBackspace(oldValue, newValue)
-
-        // Should not match because bullet is not at start of line
-        assertEquals("text -item", result.text)
-    }
-
-    @Test
-    fun `full workflow - create list, add items, remove empty item`() {
-        // Start with first item and newline already inserted
-        var value = TextFieldValue("- first\n", TextRange(8))
-
-        // Press Enter to continue list
-        value = MarkdownUtils.handleEnterKey(value)
-        assertEquals("- first\n- ", value.text)
-        assertEquals(TextRange(10), value.selection)
-
-        // Type second item (simulating user typing "second")
-        value = value.copy(text = "- first\n- second", selection = TextRange(16))
-        
-        // User presses Enter - newline is added by IME
-        val newValue = value.copy(text = "- first\n- second\n", selection = TextRange(17))
-        value = MarkdownUtils.handleEnterKey(newValue)
-        assertEquals("- first\n- second\n- ", value.text)
-        assertEquals(TextRange(19), value.selection)
-        
-        // Remove it with backspace (user deletes the space of "- ")
-        val deletedSpaceValue = value.copy(text = "- first\n- second\n-", selection = TextRange(18))
-        value = MarkdownUtils.handleBackspace(value, deletedSpaceValue)
-        assertEquals("- first\n- second\n", value.text)
-        assertEquals(TextRange(17), value.selection)
-    }
-
-    @Test
-    fun `complex indented list workflow`() {
-        // Start with root item and newline
-        var value = TextFieldValue("- root\n", TextRange(7))
-
-        // Add indented child - newline already inserted
-        value = MarkdownUtils.handleEnterKey(value)
-        // Now we have "- root\n- " but we want to make it indented
-        // Simulate user pressing space twice to indent
-        value = value.copy(text = "- root\n  - ", selection = TextRange(11))
-        // User types "child"
-        value = value.copy(text = "- root\n  - child", selection = TextRange(16))
-        
-        // User presses Enter - newline added by IME
-        val newValue = value.copy(text = "- root\n  - child\n", selection = TextRange(17))
-        value = MarkdownUtils.handleEnterKey(newValue)
-        assertEquals("- root\n  - child\n  - ", value.text)
-        assertEquals(TextRange(21), value.selection)
-
-        // Remove the empty indented item (user deletes space of "  - ")
-        val deletedSpaceValue = value.copy(text = "- root\n  - child\n  -", selection = TextRange(20))
-        value = MarkdownUtils.handleBackspace(value, deletedSpaceValue)
-        assertEquals("- root\n  - child\n", value.text)
-        assertEquals(TextRange(17), value.selection)
+    fun `handleListInput removes indented bullet on backspace`() {
+        val state = TextFieldState("  - item", TextRange(4))
+        state.edit {
+            replace(3, 4, "") // Delete space
+            MarkdownUtils.handleListInput(this)
+        }
+        assertEquals("item", state.text.toString())
+        assertEquals(TextRange(0), state.selection)
     }
 
     @Test
@@ -339,8 +101,8 @@ class MarkdownUtilsTest {
 
         val match = regex.find(text)
         assertNotNull(match)
-        assertEquals("", match!!.groups[1]!!.value) // No leading whitespace
-        assertEquals("-", match.groups[2]!!.value)  // Dash bullet
+        assertEquals("", match!!.groups[1]!!.value)
+        assertEquals("-", match.groups[2]!!.value)
     }
 
     @Test
@@ -350,25 +112,7 @@ class MarkdownUtilsTest {
 
         val match = regex.find(text)
         assertNotNull(match)
-        assertEquals("  ", match!!.groups[1]!!.value) // Two spaces
-        assertEquals("*", match.groups[2]!!.value)   // Asterisk bullet
-    }
-
-    @Test
-    fun `bullet regex does not match without trailing space`() {
-        val regex = Regex("^(\\s*)([-*])\\s")
-        val text = "-item"
-
-        val match = regex.find(text)
-        assertTrue(match == null)
-    }
-
-    @Test
-    fun `bullet regex does not match in middle of text`() {
-        val regex = Regex("^(\\s*)([-*])\\s")
-        val text = "prefix - item"
-
-        val match = regex.find(text)
-        assertTrue(match == null)
+        assertEquals("  ", match!!.groups[1]!!.value)
+        assertEquals("*", match.groups[2]!!.value)
     }
 }


### PR DESCRIPTION
This should make the text manipulation (markdown rendering and list logic) much more stable and safe and will (hopefully) fix the issue of duplicated lines on Samsung devices.
This might close #14 and it might close #17 